### PR TITLE
Removed huge duplication of ansible_user and become settings across hosts

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,3 +1,7 @@
+ansible_user: ec2-user
+ansible_become: true
+ansible_become_method: sudo
+
 mapr_release_url: http://package.mapr.com/releases/v6.0.0
 mapr_ecosystem_url: http://package.mapr.com/releases/MEP/MEP-4.0.0/
 mapr_gpg_url: http://package.mapr.com/releases/pub/maprgpg.key

--- a/myhosts/hosts_3nodes
+++ b/myhosts/hosts_3nodes
@@ -2,89 +2,89 @@
 # Write unprovisioned instances here, so that Ansible is aware of host and can uninstall
 # This stays empty unless you want to remove a node
 [unprovision]
-#10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.156
 
 [ext-kerberos]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 [common]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 [mapr-core]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # Zookeeper
 [mapr-zookeeper]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # Container Location DataBase
 [mapr-cldb]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 # Kafka API for MapR-Streams
 [mapr-kafka]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # Gateway for Streams and MapR-DB
 [mapr-gateway]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # MapR Control System
 [mapr-mcs]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 # YARN resource manager
 [mapr-resourcemanager]
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.86
+10.0.0.156
 
 # Job History Server, IMPORTANT: only one
 [mapr-historyserver]
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.156
 
 # Contains YARN Node Manager, MapReduce2 and MapR FileServer (MFS)
 [mapr-datanode]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # MySQL, required for Hive MetaStore and Oozie, IMPORTANT: only one
 [ext-mysql]
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.156
 
 # Spark on YARN
 [mapr-spark-yarn]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # Spark HistoryServer
 [mapr-spark-historyserver]
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.86
 
 # NFS
 [mapr-nfs]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # MapR Fuse Posix Client Basic
 [mapr-posix-client-basic]
-#10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.68
+#10.0.0.86
+#10.0.0.156
 
 # MapR Fuse Posix Client Platinum
 [mapr-posix-client-platinum]
@@ -92,79 +92,79 @@
 
 # Apache Drill
 [mapr-drill-standalone]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # Apache Drill
 [mapr-drill-yarn]
 
 # Flume
 [mapr-flume]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # HBase CLI
 [mapr-hbase-cli]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # HBase REST and Thrift
 [mapr-hbase-thrift-rest]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 # Hive CLI
 [mapr-hive-cli]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # Hive Meta Store
 [mapr-hive-metastore]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 # Hive Server2
 [mapr-hive-server2]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 # Hive WebHCat
 [mapr-hive-webhcat]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 # HttpFS
 [mapr-httpfs]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 [mapr-hue]
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.156
 
 # Sqoop1
 [mapr-sqoop1]
-#10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.68
+#10.0.0.86
+#10.0.0.156
 
 # Sqoop2 Server
 [mapr-sqoop2-server]
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.86
 
 # Sqoop2 Client
 [mapr-sqoop2-client]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # Pig
 [mapr-pig]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
+10.0.0.86
+10.0.0.156
 
 # Oozie
 [mapr-oozie]
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.86
 
 # CollectD
 [mapr-collectd:children]
@@ -172,15 +172,15 @@ mapr-core
 
 # OpenTSDB
 [mapr-opentsdb]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 # Custom OpenTSDB, do NOT install on same node as mapr-opentsdb
 [mapr-opentsdb-custom]
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.86
 
 # Grafana
 [mapr-grafana]
-10.0.0.68 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.68
 
 # FluentD
 [mapr-fluentd:children]
@@ -188,12 +188,12 @@ mapr-core
 
 # ElasticSearch
 [mapr-elasticsearch]
-10.0.0.86 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.86
+10.0.0.156
 
 # Kibana
 [mapr-kibana]
-10.0.0.156 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.156
 
 
 

--- a/myhosts/hosts_4nodes
+++ b/myhosts/hosts_4nodes
@@ -2,93 +2,93 @@
 # Write unprovisioned instances here, so that Ansible is aware of host and can uninstall
 # This stays empty unless you want to remove a node
 [unprovision]
-#10.0.0.145 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.145
 
 [common]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 [mapr-core]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # Zookeeper
 [mapr-zookeeper]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
 
 # Container Location DataBase
 [mapr-cldb]
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # Kafka API for MapR-Streams
 [mapr-kafka]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # Gateway for Streams and MapR-DB
 [mapr-gateway]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # MapR Control System
 [mapr-mcs]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
 
 # YARN resource manager
 [mapr-resourcemanager]
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # Job History Server, IMPORTANT: only one
 [mapr-historyserver]
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-203.ps.mapr.com
 
 # Contains YARN Node Manager, MapReduce2 and MapR FileServer (MFS)
 [mapr-datanode]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # MySQL, required for Hive MetaStore and Oozie, IMPORTANT: only one
 [ext-mysql]
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-148.ps.mapr.com
 
 # Spark on YARN
 [mapr-spark-yarn]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # Spark HistoryServer
 [mapr-spark-historyserver]
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-203.ps.mapr.com
 
 # NFS
 [mapr-nfs]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # MapR Fuse Posix Client Basic
 [mapr-posix-client-basic]
-#10.0.0.84 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.92 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.145 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.84
+#10.0.0.92
+#10.0.0.145
 
 # MapR Fuse Posix Client Platinum
 [mapr-posix-client-platinum]
@@ -96,10 +96,10 @@ ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_becom
 
 # Apache Drill
 [mapr-drill-standalone]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # Apache Drill
 [mapr-drill-yarn]
@@ -109,40 +109,40 @@ ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_becom
 
 # HBase CLI
 [mapr-hbase-cli]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # HBase REST and Thrift
 [mapr-hbase-thrift-rest]
-#ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#ip-10-0-0-203.ps.mapr.com
 
 # Hive CLI
 [mapr-hive-cli]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # Hive Meta Store
 [mapr-hive-metastore]
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-113.ps.mapr.com
 
 # Hive Server2
 [mapr-hive-server2]
-#ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#ip-10-0-0-203.ps.mapr.com
 
 # Hive WebHCat
 [mapr-hive-webhcat]
-#10.0.0.84 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.84
 
 # HttpFS
 [mapr-httpfs]
-#ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#ip-10-0-0-203.ps.mapr.com
 
 [mapr-hue]
-#ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#ip-10-0-0-113.ps.mapr.com
 
 # Mahout
 [mapr-mahout]
@@ -161,14 +161,14 @@ ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_becom
 
 # Pig
 [mapr-pig]
-#ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#ip-10-0-0-83.ps.mapr.com
+#ip-10-0-0-113.ps.mapr.com
+#ip-10-0-0-148.ps.mapr.com
+#ip-10-0-0-203.ps.mapr.com
 
 # Oozie
 [mapr-oozie]
-#ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#ip-10-0-0-203.ps.mapr.com
 
 # CollectD
 [mapr-collectd:children]
@@ -176,15 +176,15 @@ mapr-core
 
 # OpenTSDB
 [mapr-opentsdb]
-ip-10-0-0-83.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-113.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-83.ps.mapr.com
+ip-10-0-0-113.ps.mapr.com
 
 # Custom OpenTSDB, do NOT install on same node as mapr-opentsdb
 [mapr-opentsdb-custom]
 
 # Grafana
 [mapr-grafana]
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-203.ps.mapr.com
 
 # FluentD
 [mapr-fluentd:children]
@@ -192,12 +192,12 @@ mapr-core
 
 # ElasticSearch
 [mapr-elasticsearch]
-ip-10-0-0-148.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-148.ps.mapr.com
+ip-10-0-0-203.ps.mapr.com
 
 # Kibana
 [mapr-kibana]
-ip-10-0-0-203.ps.mapr.com ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+ip-10-0-0-203.ps.mapr.com
 
 
 

--- a/myhosts/hosts_client
+++ b/myhosts/hosts_client
@@ -5,34 +5,34 @@
 
 # Zookeeper
 [mapr-zookeeper]
-10.0.0.63 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.83 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.131 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.63
+10.0.0.83
+10.0.0.131
 
 # Container Location DataBase
 [mapr-cldb]
-10.0.0.63 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.83 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.131 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.63
+10.0.0.83
+10.0.0.131
 
 
 # Hive Meta Store
 [mapr-hive-metastore]
-10.0.0.83 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.83
 
 ######################################################################################
 
 # sets up ntp, rpcbind, Java and mapr default user with standard password mapr123
 [common]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # MapR-Client
 [mapr-client]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # Spark on YARN, requires Hive!
 [mapr-spark-yarn]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # NFS loopback, ATTENTION: install only on edge node (mapr-client)!!!
 [mapr-nfsloopback]
@@ -45,14 +45,14 @@
 
 # HBase CLI
 [mapr-hbase-cli]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # HBase REST and Thrift
 [mapr-hbase-thrift-rest]
 
 # Hive CLI
 [mapr-hive-cli]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # Hive Server2
 [mapr-hive-server2]
@@ -85,7 +85,7 @@
 
 # MapR Fuse Posix Client Basic
 [mapr-posix-client-basic]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # MapR Fuse Posix Client Platinum
 [mapr-posix-client-platinum]

--- a/myhosts/hosts_debug
+++ b/myhosts/hosts_debug
@@ -1,5 +1,5 @@
 [common]
-10.0.0.28 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.33 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.166 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.28
+10.0.0.33
+10.0.0.166
 

--- a/myhosts/hosts_kerberos
+++ b/myhosts/hosts_kerberos
@@ -5,85 +5,85 @@
 [unprovision]
 
 [ext-kerberos]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # sets up ntp, rpcbind, Java and mapr default user with standard password mapr123
 [common]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 [mapr-core]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # Zookeeper
 [mapr-zookeeper]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # Container Location DataBase
 [mapr-cldb]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
 
 # Kafka API for MapR-Streams
 [mapr-kafka]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # Gateway for Streams and MapR-DB
 [mapr-gateway]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # MapR Control System
 [mapr-mcs]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.194
 
 # YARN resource manager
 [mapr-resourcemanager]
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.153
+10.0.0.194
 
 # Job History Server, IMPORTANT: only one
 [mapr-historyserver]
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.194
 
 # Contains YARN Node Manager, MapReduce2 and MapR FileServer (MFS)
 [mapr-datanode]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # MySQL, required for Hive MetaStore and Oozie, IMPORTANT: only one
 [ext-mysql]
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.153
 
 # Spark on YARN
 [mapr-spark-yarn]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # Spark HistoryServer
 [mapr-spark-historyserver]
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.153
 
 # NFS
 [mapr-nfs]
 
 # MapR Fuse Posix Client Basic
 [mapr-posix-client-basic]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # MapR Fuse Posix Client Platinum
 [mapr-posix-client-platinum]
@@ -91,9 +91,9 @@
 
 # Apache Drill
 [mapr-drill-standalone]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # Apache Drill
 [mapr-drill-yarn]
@@ -103,29 +103,29 @@
 
 # HBase CLI
 [mapr-hbase-cli]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # HBase REST and Thrift
 [mapr-hbase-thrift-rest]
-#10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.136
 
 # Hive CLI
 [mapr-hive-cli]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
+10.0.0.194
 
 # Hive Meta Store
 [mapr-hive-metastore]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
 
 # Hive Server2
 [mapr-hive-server2]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
+10.0.0.153
 
 # Hive HCatalog
 [mapr-hive-hcatalog]
@@ -135,32 +135,32 @@
 
 # HttpFS
 [mapr-httpfs]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
 
 [mapr-hue]
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.153
+10.0.0.194
 
 # Sqoop2 Server
 [mapr-sqoop2-server]
-#10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.153
 
 # Sqoop2 Client
 [mapr-sqoop2-client]
-#10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.136
+#10.0.0.153
+#10.0.0.194
 
 # Pig
 [mapr-pig]
-#10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-#10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+#10.0.0.136
+#10.0.0.153
+#10.0.0.194
 
 # Oozie
 [mapr-oozie]
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.153
+10.0.0.194
 
 # CollectD
 [mapr-collectd:children]
@@ -168,15 +168,15 @@ mapr-core
 
 # OpenTSDB
 [mapr-opentsdb]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
 
 # Custom OpenTSDB, do NOT install on same node as mapr-opentsdb
 [mapr-opentsdb-custom]
-10.0.0.153 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.153
 
 # Grafana
 [mapr-grafana]
-10.0.0.136 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.136
 
 # FluentD
 [mapr-fluentd:children]
@@ -184,11 +184,11 @@ mapr-core
 
 # ElasticSearch
 [mapr-elasticsearch]
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.194
 
 # Kibana
 [mapr-kibana]
-10.0.0.194 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.194
 
 
 

--- a/myhosts/hosts_maprvolumes
+++ b/myhosts/hosts_maprvolumes
@@ -4,4 +4,4 @@
 
 # Zookeeper
 [volumes]
-10.0.0.94 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.94

--- a/myhosts/hosts_single
+++ b/myhosts/hosts_single
@@ -9,7 +9,7 @@
 #security_all=kerberos
 
 [common]
-10.0.0.127 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.127
 
 [ext-kerberos:children]
 #common

--- a/myhosts/hosts_ui
+++ b/myhosts/hosts_ui
@@ -1,7 +1,7 @@
 [hosts]
-10.0.0.121 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.122 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.123 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.121
+10.0.0.122
+10.0.0.123
 
 [master]
-10.0.0.121 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.121

--- a/myhosts/hosts_zeppelin
+++ b/myhosts/hosts_zeppelin
@@ -2,5 +2,5 @@
 
 # Zeppelin
 [ext-zeppelin]
-10.0.0.197 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.197
 


### PR DESCRIPTION
Hi @devproof / MapR

Thanks very much for this repo - we are starting to use it at a large financial client of MapR and would like to start fixing up some of the things to make it easier to use across environments.

This first pull request is merely a clean up of a lot of duplicated settings in host inventory files. It doesn't seem necessary to have all these redundant ansible_user/become/become_method settings as there shouldn't be any difference between cluster hosts, although if there were then it could still be overridden on a per host basis.

Thanks

Hari