### PR TITLE
fix hue.ini (control structure)

### DIFF
--- a/roles/mapr-hue-install/templates/hue.ini
+++ b/roles/mapr-hue-install/templates/hue.ini
@@ -71,7 +71,7 @@
 
   # This property specifies the maximum size of the receive buffer in bytes in thrift sasl communication (default 2 MB).
   ## sasl_max_buffer=2 * 1024 * 1024
-  {% if hue_ssl %}
+  {% if hue_ssl is defined %}
   # Filename of SSL Certificate
   ssl=True
   ssl_certificate=/opt/mapr/hue/hue-{{ version_output.stdout }}/desktop/conf/server.crt
@@ -159,7 +159,7 @@
 
   # Comma separated list of apps to not load at server startup.
   # e.g.: pig,zookeeper
-  app_blacklist={{ 'oozie,jobsub,' if not hue_oozie_string else ''}}{{ 'beeswax,' if not hue_hiveserver2_string else ''}}{{ 'sqoop,sqoop2,' if not hue_sqoopserver2_string else ''}}search,zookeeper,impala,pig,security
+  app_blacklist={{ 'oozie,jobsub,' if hue_oozie_string is not defined else ''}}{{ 'beeswax,' if hue_hiveserver2_string is not defined else ''}}{{ 'sqoop,sqoop2,' if hue_sqoopserver2_string is not defined else ''}}search,zookeeper,impala,pig,security
 
   # Choose whether to show the new SQL editor.
   ## use_new_editor=true
@@ -824,7 +824,7 @@
       # Use WebHdfs/HttpFs as the communication mechanism.
       # Domain should be the NameNode or HttpFs host.
       # Default port is 14000 for HttpFs.
-      {% if hue_oozie_string %}
+      {% if hue_oozie_string is defined %}
       webhdfs_url={{ hue_httpfs_string }}
       {% endif %}
 
@@ -882,11 +882,11 @@
       # proxy_api_url=http://localhost:8088
 
       # URL of the HistoryServer API
-      {% if hue_historyserver_string %}
+      {% if hue_historyserver_string is defined %}
       history_server_api_url=http://{{ hue_historyserver_string }}:19888
       {% endif %}
       # URL of the Spark History Server
-      {% if hue_sparkhistoryserver_string %}
+      {% if hue_sparkhistoryserver_string is defined %}
       spark_history_server_url=http://{{ hue_sparkhistoryserver_string }}:18088
       {% endif %}
 
@@ -952,7 +952,7 @@
 ###########################################################################
 
 [liboozie]
-  {% if hue_oozie_string %}
+  {% if hue_oozie_string is defined %}
   # The URL where the Oozie service runs on. This is required in order for
   # users to submit jobs. Empty value disables the config check.
   oozie_url={{ hue_oozie_string }}
@@ -1005,7 +1005,7 @@
 [beeswax]
 
   #{ if hue_hive_path_result.matched is defined and hue_hive_path_result.matched == 1 and hue_hiveserver2_string }
-  {% if hue_hiveserver2_string %}
+  {% if hue_hiveserver2_string is defined %}
 
   # Host where HiveServer2 is running.
   # If Kerberos security is enabled, use fully-qualified domain name (FQDN).
@@ -1202,7 +1202,7 @@
 ###########################################################################
 
 [sqoop]
-  {% if hue_sqoopserver2_string %}
+  {% if hue_sqoopserver2_string is defined %}
   # For autocompletion, fill out the librdbms section.
 
   # Sqoop server URL
@@ -1238,7 +1238,7 @@
   # Comma-separated list of HBase Thrift servers for clusters in the format of '(name|host:port)'.
   # Use full hostname with security.
   # If using Kerberos we assume GSSAPI SASL, not PLAIN.
-  {% if hue_hbasethriftserver_string %}
+  {% if hue_hbasethriftserver_string is defined %}
   hbase_clusters={{ hue_hbasethriftserver_string }}
 #  hbase_clusters=({{ cluster_name }}|{{ hue_hbasethriftserver_string }}:9090)
   {% endif %}


### PR DESCRIPTION
- When deployed the cluster with hue and without sqoop/oozie..., in the hue.ini template, the control was not capable to test if the variable is undefined ( as mentioned in the documentation: http://jinja.pocoo.org/docs/2.9/templates/#if )
- Tested on ansible 2.4 and 2.5