### PR TITLE
MapR Kerberos principal + LDAP DN variable substitution

### DIFF
--- a/roles/ext-ad-createusers/tasks/main.yml
+++ b/roles/ext-ad-createusers/tasks/main.yml
@@ -7,7 +7,7 @@
   copy: src=ad-change-pwd-0.1.jar dest=/tmp/ad-change-pwd-0.1.jar
 - name: Create kerberos user for cluster
   ldap_entry:
-    dn: "CN=mapr-{{ cluster_name }},{{ mapr_kerberos_ad_user_cn }}"
+    dn: "CN={{ mapr_user }}-{{ cluster_name }},{{ mapr_kerberos_ad_user_cn }}"
     state: present
 #    start_tls: true
     objectClass:
@@ -16,10 +16,10 @@
       - top
       - user
     attributes:
-      cn: "mapr-{{ cluster_name }}"
-      displayName: "mapr-{{ cluster_name }}"
-      name: "mapr-{{ cluster_name }}"
-      sAMAccountName: "mapr-{{ cluster_name }}"
+      cn: "{{ mapr_user }}-{{ cluster_name }}"
+      displayName: "{{ mapr_user }}-{{ cluster_name }}"
+      name: "{{ mapr_user }}-{{ cluster_name }}"
+      sAMAccountName: "{{ mapr_user }}-{{ cluster_name }}"
       instanceType: 4
       objectCategory: "{{ mapr_kerberos_ad_object_category }}"
       servicePrincipalName: "mapr/{{ cluster_name }}"
@@ -30,7 +30,7 @@
     bind_pw: "{{ mapr_kerberos_admin_bind_pw }}"
   when: inventory_hostname == groups["ext-kerberos"][0]
 - name: Set password for cluster user
-  command: "java -jar /tmp/ad-change-pwd-0.1.jar {{ mapr_kerberos_kdc }} 636 '{{ mapr_kerberos_admin_bind_dn }}' '{{ mapr_kerberos_admin_bind_pw }}' 'CN=mapr-{{ cluster_name }},{{ mapr_kerberos_ad_user_cn }}' '{{ mapr_kerberos_keytab_passwd }}'"
+  command: "java -jar /tmp/ad-change-pwd-0.1.jar {{ mapr_kerberos_kdc }} 636 '{{ mapr_kerberos_admin_bind_dn }}' '{{ mapr_kerberos_admin_bind_pw }}' 'CN={{ mapr_user }}-{{ cluster_name }},{{ mapr_kerberos_ad_user_cn }}' '{{ mapr_kerberos_keytab_passwd }}'"
   when: inventory_hostname == groups["ext-kerberos"][0]
 - name: Create kerberos users
   vars:

--- a/roles/ext-kerberos-keytabs-ad-generate/templates/ktutil.txt
+++ b/roles/ext-kerberos-keytabs-ad-generate/templates/ktutil.txt
@@ -1,6 +1,6 @@
-add_entry -password -p mapr/{{ cluster_name }} -k 1 -e  RC4-HMAC
+add_entry -password -p {{ mapr_user }}/{{ cluster_name }} -k 1 -e  RC4-HMAC
 {{ mapr_kerberos_keytab_passwd }}
-add_entry -password -p mapr/{{ ansible_fqdn }} -k 1 -e  RC4-HMAC
+add_entry -password -p {{ mapr_user }}/{{ ansible_fqdn }} -k 1 -e  RC4-HMAC
 {{ mapr_kerberos_keytab_passwd }}
 add_entry -password -p HTTP/{{ ansible_fqdn }} -k 1 -e  RC4-HMAC
 {{ mapr_kerberos_keytab_passwd }}

--- a/roles/ext-kerberos-verify-keytabs/tasks/main.yml
+++ b/roles/ext-kerberos-verify-keytabs/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Copy mapr.keytab
   copy: src={{ mapr_kerberos_local_keytabs_dir }}/{{ ansible_fqdn }}.keytab dest=/tmp/mapr.keytab
 
-- name: Verify mapr/<hostname> keytab
-  command: kinit -k -t /tmp/mapr.keytab mapr/{{ ansible_fqdn }}@{{ mapr_kerberos_realm }}
+- name: Verify {{ mapr_user }}/<hostname> keytab
+  command: kinit -k -t /tmp/mapr.keytab {{ mapr_user }}/{{ ansible_fqdn }}@{{ mapr_kerberos_realm }}
 #  when: inventory_hostname in groups["mapr-core"]
 - name: Display current ticket mapr
   command: klist
@@ -29,7 +29,7 @@
 #  when: inventory_hostname in groups["mapr-core"]
 
 - name: Verify Cluster keytab
-  command: kinit -k -t /tmp/mapr.keytab mapr/{{ cluster_name }}
+  command: kinit -k -t /tmp/mapr.keytab {{ mapr_user }}/{{ cluster_name }}
 - name: Display current ticket mapr
   command: klist
   register: klist_out

--- a/roles/mapr-configure-kerberos/tasks/main.yml
+++ b/roles/mapr-configure-kerberos/tasks/main.yml
@@ -8,7 +8,7 @@
   stat: path=/opt/mapr/conf/cldb.key
   register: cldb_key_status
 - name: Configure.sh to generate keys just run on first mapr-core node
-  shell: /opt/mapr/server/configure.sh -N {{ cluster_name }} -Z {{ zookeeper_string }} -C {{ cldb_string }} -u {{ mapr_user }} -g {{ mapr_group }} -genkeys -secure -K -P "mapr/{{ cluster_name }}@{{ mapr_kerberos_realm }}"  -HS {{ historyserver_string }}
+  shell: /opt/mapr/server/configure.sh -N {{ cluster_name }} -Z {{ zookeeper_string }} -C {{ cldb_string }} -u {{ mapr_user }} -g {{ mapr_group }} -genkeys -secure -K -P "{{ mapr_user }}/{{ cluster_name }}@{{ mapr_kerberos_realm }}"  -HS {{ historyserver_string }}
   when: inventory_hostname == groups["mapr-cldb"][0] and not cldb_key_status.stat.exists
 - name: Copy keys to local
   fetch: src=/opt/mapr/conf/{{ item }} dest=/tmp/{{ item }} flat=yes
@@ -28,4 +28,4 @@
  # copy to other nodes
  # run configure on other nodes
 - name: Configure.sh kerberos
-  shell: /opt/mapr/server/configure.sh -N {{ cluster_name }} -Z {{ zookeeper_string }} -C {{ cldb_string }} -u {{ mapr_user }} -g {{mapr_group}} -secure -K -P "mapr/{{ cluster_name }}@{{ mapr_kerberos_realm }}" -HS {{ historyserver_string }}
+  shell: /opt/mapr/server/configure.sh -N {{ cluster_name }} -Z {{ zookeeper_string }} -C {{ cldb_string }} -u {{ mapr_user }} -g {{mapr_group}} -secure -K -P "{{ mapr_user }}/{{ cluster_name }}@{{ mapr_kerberos_realm }}" -HS {{ historyserver_string }}


### PR DESCRIPTION
Set all Kerberos principals and LDAP DNs to {{ mapr_user }} a variable instead of hardcoded mapr user for environments where this may be set differently.

For example dev / staging / prod environments may have different AD users to not overlap eg. maprd / maprs / maprp AD accounts respectively for dev, staging and prod to not use the same account for all environments which large enterprises like banks do not like.