### PR TITLE
MapR warden.conf permissions fix for environments with restrictive UMASK

### DIFF
--- a/roles/mapr-configure-warden-cldb-restart/tasks/main.yml
+++ b/roles/mapr-configure-warden-cldb-restart/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 # Restart  Warden
+- name: Ensure warden.conf is owned by mapr user
+  file: path=/opt/mapr/conf/warden.conf owner={{ mapr_user }} group={{ mapr_group }}
 - name: Stop Warden
   service: name=mapr-warden state=stopped enabled=yes
 - name: Delete /opt/mapr/logs/cldb.log


### PR DESCRIPTION
We have found warden.conf is often set to root and this breaks the cluster coming up in our environments (probably where the base OS's UMASK is set more restrictive than yours as the file ends up with root:root 0600 permissions).

By setting warden.conf to be owned by the mapr user this seems to fix this and allows the warden process to start and bring up the cluster. fails to come up