### PR TITLE
Host inventory deduplication of vars using [all:vars]

### DIFF
--- a/host_templates/hosts_anaconda
+++ b/host_templates/hosts_anaconda
@@ -1,4 +1,6 @@
 [all:vars]
+ansible_user=ec2-user
+ansible_become=yes
 anaconda_install_binary=/mapr/demo.mapr.com/tools/anaconda/anaconda_installer/Anaconda3-5.0.1-Linux-x86_64.sh
 anaconda_install_path=/mapr/demo.mapr.com/tools/anaconda/anaconda
 anaconda_repo_path=file://mapr/demo.mapr.com/tools/anaconda/anaconda_repos/repo.continuum.io
@@ -9,10 +11,10 @@ anaconda_python_version=3.5
 anaconda_packages=fbprophet colorama cycler dill fastparquet libxgboost numpy numba matplotlib mkl pandas patsy py pyodbc pytest pyparsing psutil scikit-learn scipy statsmodels thrift wheel jupyter
 
 [ext-anaconda-python]
-10.0.0.70 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.70
 
 # Spark on YARN
 [mapr-spark-yarn]
-10.0.0.70 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.229 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.246 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.70
+10.0.0.229
+10.0.0.246

--- a/host_templates/hosts_client
+++ b/host_templates/hosts_client
@@ -1,55 +1,59 @@
 # If you do not want to install a component leave the block empty
 
+[all:vars]
+ansible_user=ec2-user
+ansible_become=yes
+
 ###### These ones are not installed, just required for config generation ############
 
 # Zookeeper
 [mapr-zookeeper]
-10.0.0.242 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.243 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.244 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.242
+10.0.0.243
+10.0.0.244
 
 # Container Location DataBase
 [mapr-cldb]
-10.0.0.242 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.243 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.244 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.242
+10.0.0.243
+10.0.0.244
 
 # Hive Meta Store
 [mapr-hive-metastore]
-10.0.0.243 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.243
 
 ######################################################################################
 
 # sets up ntp, rpcbind, Java and mapr default user with standard password mapr123
 [common]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 [mapr-client]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Spark on YARN
 [mapr-spark-yarn]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # NFS loopback, ATTENTION: install only on edge node (mapr-client)!!!
 [mapr-nfsloopback]
-#10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+#10.0.0.132
 
 # Flume
 [mapr-flume]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # HBase CLI
 [mapr-hbase-cli]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive CLI
 [mapr-hive-cli]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Pig
 [mapr-pig]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # MapR NFS loopback (only for MapR client!)
 [mapr-nfsloopback]

--- a/host_templates/hosts_cluster
+++ b/host_templates/hosts_cluster
@@ -1,4 +1,9 @@
 # If you do not want to install a component leave the block empty
+
+[all:vars]
+ansible_user=ec2-user
+ansible_become=yes
+
 # sets up ntp, rpcbind, Java and mapr default user with standard password mapr123
 # Write unprovisioned instances here, so that Ansible is aware of host and can uninstall
 # This stays empty unless you want to remove a node
@@ -6,60 +11,60 @@
 
 # sets up ntp, rpcbind, Java and mapr default user with standard password mapr123
 [common]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 [mapr-core]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Zookeeper
 [mapr-zookeeper]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Contains MapR FileServer (MFS)
 [mapr-fileserver]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Container Location DataBase
 [mapr-cldb]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Gateway for Streams and MapR-DB
 [mapr-gateway]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # MapR Control System
 [mapr-mcs]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # YARN resource manager
 [mapr-resourcemanager]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Contains YARN Node Manager
 [mapr-nodemanager]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 
 # Job History Server, IMPORTANT: only one
 [mapr-historyserver]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 
 # MySQL, required for Hive MetaStore and Oozie, IMPORTANT: only one
 [ext-mysql]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Spark on YARN
 [mapr-spark-yarn]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Spark ThriftServer
 [mapr-spark-thriftserver]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Spark HistoryServer
 [mapr-spark-historyserver]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # MapR Fuse Posix Client Basic
 [mapr-posix-client-basic]
@@ -69,78 +74,78 @@
 
 # NFS
 [mapr-nfs]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Apache Drill
 [mapr-drill-standalone]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Apache Drill
 [mapr-drill-yarn]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Flume
 [mapr-flume]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # HBase CLI
 [mapr-hbase-cli]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # HBase REST and Thrift
 [mapr-hbase-thrift-rest]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive CLI
 [mapr-hive-cli]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive Meta Store
 [mapr-hive-metastore]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive Server2
 [mapr-hive-server2]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive HCatalog
 [mapr-hive-hcatalog]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive WebHCat
 [mapr-hive-webhcat]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # HttpFS
 [mapr-httpfs]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 [mapr-hue]
-# 10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+# 10.0.0.132
 
 # Sqoop1
 [mapr-sqoop1]
-10.0.0.132 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Sqoop2 Server
 [mapr-sqoop2-server]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Sqoop2 Client
 [mapr-sqoop2-client]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Pig
 [mapr-pig]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Oozie
 [mapr-oozie]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # File Migrate Service
 [mapr-filemigrate]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 [mapr-impala-server]
 
@@ -159,15 +164,15 @@ mapr-core
 
 # OpenTSDB
 [mapr-opentsdb]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Custom OpenTSDB, do NOT install on same node as mapr-opentsdb
 [mapr-opentsdb-custom]
-10.0.0.132 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Grafana
 [mapr-grafana]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # FluentD
 [mapr-fluentd:children]
@@ -175,9 +180,9 @@ mapr-core
 
 # ElasticSearch
 [mapr-elasticsearch]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Kibana
 [mapr-kibana]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 

--- a/host_templates/hosts_cluster_withvars
+++ b/host_templates/hosts_cluster_withvars
@@ -5,6 +5,8 @@
 [all:vars]
 cluster_name=demo.mapr.com
 security_all=maprsasl
+ansible_user=ec2-user
+ansible_become=yes
 
 # Write unprovisioned instances here, so that Ansible is aware of host and can uninstall
 # This stays empty unless you want to remove a node
@@ -12,58 +14,58 @@ security_all=maprsasl
 
 # sets up ntp, rpcbind, Java and mapr default user with standard password mapr123
 [common]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 [mapr-core]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Zookeeper
 [mapr-zookeeper]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Contains MapR FileServer (MFS)
 [mapr-fileserver]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Container Location DataBase
 [mapr-cldb]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Gateway for Streams and MapR-DB
 [mapr-gateway]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # MapR Control System
 [mapr-mcs]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # YARN resource manager
 [mapr-resourcemanager]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Contains YARN Node Manager
 [mapr-nodemanager]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Job History Server, IMPORTANT: only one
 [mapr-historyserver]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # MySQL, required for Hive MetaStore and Oozie, IMPORTANT: only one
 [ext-mysql]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Spark on YARN
 [mapr-spark-yarn]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Spark ThriftServer
 [mapr-spark-thriftserver]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Spark HistoryServer
 [mapr-spark-historyserver]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # MapR Fuse Posix Client Basic
 [mapr-posix-client-basic]
@@ -73,78 +75,78 @@ security_all=maprsasl
 
 # NFS
 [mapr-nfs]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Apache Drill
 [mapr-drill-standalone]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Apache Drill
 [mapr-drill-yarn]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Flume
 [mapr-flume]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # HBase CLI
 [mapr-hbase-cli]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # HBase REST and Thrift
 [mapr-hbase-thrift-rest]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive CLI
 [mapr-hive-cli]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive Meta Store
 [mapr-hive-metastore]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive Server2
 [mapr-hive-server2]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive HCatalog
 [mapr-hive-hcatalog]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Hive WebHCat
 [mapr-hive-webhcat]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # HttpFS
 [mapr-httpfs]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 [mapr-hue]
-# 10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+# 10.0.0.132
 
 # Sqoop1
 [mapr-sqoop1]
-10.0.0.132 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Sqoop2 Server
 [mapr-sqoop2-server]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Sqoop2 Client
 [mapr-sqoop2-client]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Pig
 [mapr-pig]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Oozie
 [mapr-oozie]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # File Migrate Service
 [mapr-filemigrate]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 [mapr-impala-server]
 
@@ -163,15 +165,15 @@ mapr-core
 
 # OpenTSDB
 [mapr-opentsdb]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Custom OpenTSDB, do NOT install on same node as mapr-opentsdb
 [mapr-opentsdb-custom]
-10.0.0.132 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Grafana
 [mapr-grafana]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # FluentD
 [mapr-fluentd:children]
@@ -179,9 +181,9 @@ mapr-core
 
 # ElasticSearch
 [mapr-elasticsearch]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 
 # Kibana
 [mapr-kibana]
-10.0.0.132 ansible_user=centos ansible_become=yes ansible_become_method=sudo
+10.0.0.132
 

--- a/host_templates/hosts_kerberos
+++ b/host_templates/hosts_kerberos
@@ -13,11 +13,13 @@ mapr_kerberos_admin_bind_pw="XLd$B65G%ib"
 mapr_kerberos_ad_object_category="CN=Person,CN=Schema,CN=Configuration,DC=ps,DC=mapr,DC=com"
 mapr_kerberos_ad_user_cn="CN=Users,DC=ps,DC=mapr,DC=com"
 mapr_kerberos_keytab_passwd=mapr
+ansible_user=ec2-user
+ansible_become=yes
 
 [ext-kerberos]
-node1 ansible_host=10.0.0.178 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-node2 ansible_host=10.0.0.201 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-node3 ansible_host=10.0.0.207 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+node1 ansible_host=10.0.0.178
+node2 ansible_host=10.0.0.201
+node3 ansible_host=10.0.0.207
 
 
 

--- a/myhosts/hosts_client
+++ b/myhosts/hosts_client
@@ -1,38 +1,41 @@
 # If you do not want to install a component leave the block empty
 
+[all:vars]
+ansible_user=ec2-user
+ansible_become=yes
 
 ###### These ones are not installed, just required for config generation ############
 
 # Zookeeper
 [mapr-zookeeper]
-10.0.0.63 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.83 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.131 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.63
+10.0.0.83
+10.0.0.131
 
 # Container Location DataBase
 [mapr-cldb]
-10.0.0.63 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.83 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
-10.0.0.131 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.63
+10.0.0.83
+10.0.0.131
 
 
 # Hive Meta Store
 [mapr-hive-metastore]
-10.0.0.83 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.83
 
 ######################################################################################
 
 # sets up ntp, rpcbind, Java and mapr default user with standard password mapr123
 [common]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # MapR-Client
 [mapr-client]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # Spark on YARN, requires Hive!
 [mapr-spark-yarn]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # NFS loopback, ATTENTION: install only on edge node (mapr-client)!!!
 [mapr-nfsloopback]
@@ -42,11 +45,11 @@
 
 # HBase CLI
 [mapr-hbase-cli]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # Hive CLI
 [mapr-hive-cli]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # Pig
 [mapr-pig]
@@ -59,7 +62,7 @@
 
 # MapR Fuse Posix Client Basic
 [mapr-posix-client-basic]
-10.0.0.97 ansible_user=ec2-user ansible_become=yes ansible_become_method=sudo
+10.0.0.97
 
 # MapR Fuse Posix Client Platinum
 [mapr-posix-client-platinum]


### PR DESCRIPTION
Host inventories contain a lot of duplicate settings for ansible_user and ansible_become, have moved these to a single place at the top of each inventory file.