### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+language: minimal
+
+services:
+  - docker
+
+before_install:
+  - docker pull retr0h/molecule:latest
+
+script:
+  - docker run --rm -it
+     -v "$(pwd)":/tmp/$(basename "${PWD}"):ro
+     -v /var/run/docker.sock:/var/run/docker.sock
+     -w /tmp/$(basename "${PWD}")
+     retr0h/molecule:latest
+     molecule test -s lint
+
+matrix:
+  fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MapR Ansible Scripts
+[![Build Status](https://travis-ci.org/mapr-emea/mapr-ansible.svg?branch=master)](https://travis-ci.org/mapr-emea/mapr-ansible)
 
 This is a collection of Ansible scripts which help you to setup a MapR-cluster.
 


### PR DESCRIPTION
* Automate molecule lint tests run on each push
* Show the latests tests result in the README

For this change to be fully effective, you should create a `mapr-emea` Travis acount linked to your Github account, and enable Travis on the `mapr-ansible` repo.
Travis website: https://travis-ci.org/