### PR TITLE
KSQL package added, by default starts in interactive mode only

### DIFF
--- a/myhosts/hosts_3nodes
+++ b/myhosts/hosts_3nodes
@@ -234,5 +234,11 @@ node3
 [mapr-kibana]
 node3
 
+# Kafka Ksql
+[mapr-kafka-ksql]
+node1
+node2
+node3
+
 
 

--- a/roles/mapr-kafka-ksql-install/tasks/main.yml
+++ b/roles/mapr-kafka-ksql-install/tasks/main.yml
@@ -1,0 +1,17 @@
+# Install MapR mapr-kafka-ksql, default interactive mode only
+- name: Install mapr-kafka-ksql
+  package: name=mapr-kafka-ksql state=present
+  register: mapr_kafka_ksql
+
+- name: get mapr-kafka-ksql version
+  yum:
+    list: mapr-kafka-ksql
+  register: package_name_version
+
+- name: set package version
+  set_fact:
+    package_name_version: "{{ package_name_version.results|selectattr('yumstate','equalto','installed')|map(attribute='version')|list|first }}"
+
+- name: start mapr kafka ksql
+  shell: "/opt/mapr/ksql/ksql-{{ package_name_version[:5] }}/bin/ksql-server-start /opt/mapr/ksql/ksql-{{ package_name_version[:5] }}/etc/ksql/ksqlserver.properties"
+  when: mapr_kafka_ksql.changed

--- a/roles/mapr-kafka-ksql-uninstall/tasks/main.yml
+++ b/roles/mapr-kafka-ksql-uninstall/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# Uninstall MapR Kafka KSQL
+- name: get mapr-kafka-ksql version
+  yum:
+    list: mapr-kafka-ksql
+  register: package_name_version
+
+- name: set package version
+  set_fact:
+    package_name_version: "{{ package_name_version.results|selectattr('yumstate','equalto','installed')|map(attribute='version')|list|first }}"
+
+- name: stop mapr kafka ksql
+  shell: "/opt/mapr/ksql/ksql-{{ package_name_version[:5] }}/bin/ksql-server-stop /opt/mapr/ksql/ksql-{{ package_name_version[:5] }}/etc/ksql/ksqlserver.properties"
+
+- name: Uninstall mapr-kafka-ksql
+  package: name=mapr-kafka-ksql state=absent
+

--- a/roles/tasks/main.yml
+++ b/roles/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# Uninstall MapR Kafka KSQL
+- name: get mapr-kafka-ksql version
+  yum:
+    list: mapr-kafka-ksql
+  register: package_name_version
+
+- name: set package version
+  set_fact:
+    package_name_version: "{{ package_name_version.results|selectattr('yumstate','equalto','installed')|map(attribute='version')|list|first }}"
+
+- name: stop mapr kafka ksql
+  shell: "/opt/mapr/ksql/ksql-{{ package_name_version[:5] }}/bin/ksql-server-stop /opt/mapr/ksql/ksql-{{ package_name_version[:5] }}/etc/ksql/ksqlserver.properties"
+
+- name: Uninstall mapr-kafka-ksql
+  package: name=mapr-kafka-ksql state=absent
+

--- a/sites/mapr-mep-kafka.yml
+++ b/sites/mapr-mep-kafka.yml
@@ -23,3 +23,11 @@
   hosts: all:!mapr-kafka-rest
   roles:
     - ../roles/mapr-kafka-rest-uninstall
+- name: Install Kafka KSQL
+  hosts: mapr-kafka-ksql
+  roles:
+    - ../roles/mapr-kafka-ksql-install
+- name: Uninstall Kafka KSQL
+  hosts: all:!mapr-kafka-ksql
+  roles:
+    - ../roles/mapr-kafka-ksql-uninstall


### PR DESCRIPTION
- Installs, KSQL repository
- Starts or launches ksql, from the default properties file inclusive of default port and lets the default service id be picked up as well for the ksql service id.
- Starts in interactive mode (not advisible for production), as query file is required for starting ksql in non-interactive or headless mode.